### PR TITLE
Rename analytics to search in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # twingly-analytics-api-java
 
-Java API for [Twingly Analytics](http://developer.twingly.com/resources/analytics/).
+Java API for [Twingly Search](http://developer.twingly.com/resources/search/) (previously called Twingly Analytics).
 
 To use the API you need an API key. To obtain an API key, contact us att sales@twingly.com.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # twingly-analytics-api-java
 
-Java API for [Twingly Search](http://developer.twingly.com/resources/search/) (previously called Twingly Analytics).
+Java API for [Twingly Search](http://developer.twingly.com/resources/search/) (previously known as Twingly Analytics).
 
 To use the API you need an API key. To obtain an API key, contact us at sales@twingly.com.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Java API for [Twingly Search](http://developer.twingly.com/resources/search/) (previously called Twingly Analytics).
 
-To use the API you need an API key. To obtain an API key, contact us att sales@twingly.com.
+To use the API you need an API key. To obtain an API key, contact us at sales@twingly.com.
 
 ### Example usage
 


### PR DESCRIPTION
Updated links to https://developer.twingly.com, so the documentation has to be updated first.